### PR TITLE
Track the files used to populate each segment

### DIFF
--- a/ZAPD/FileWorker.h
+++ b/ZAPD/FileWorker.h
@@ -11,5 +11,6 @@ public:
 	std::vector<ZFile*> files;
 	std::vector<ZFile*> externalFiles;
 	std::vector<int32_t> segments;
+	std::vector<ZFile*> segmentFiles;
 	std::map<int32_t, std::vector<ZFile*>> segmentRefFiles;
 };

--- a/ZAPD/Globals.cpp
+++ b/ZAPD/Globals.cpp
@@ -46,7 +46,10 @@ void Globals::AddSegment(int32_t segment, ZFile* file, int workerID)
 
 		if (std::find(worker->segments.begin(), worker->segments.end(), segment) ==
 		    worker->segments.end())
+		{
 			worker->segments.push_back(segment);
+			worker->segmentFiles.push_back(file);
+		}
 		if (worker->segmentRefFiles.find(segment) == worker->segmentRefFiles.end())
 			worker->segmentRefFiles[segment] = std::vector<ZFile*>();
 
@@ -55,7 +58,10 @@ void Globals::AddSegment(int32_t segment, ZFile* file, int workerID)
 	else
 	{
 		if (std::find(segments.begin(), segments.end(), segment) == segments.end())
+		{
 			segments.push_back(segment);
+			segmentFiles.push_back(file);
+		}
 		if (cfg.segmentRefFiles.find(segment) == cfg.segmentRefFiles.end())
 			cfg.segmentRefFiles[segment] = std::vector<ZFile*>();
 
@@ -81,7 +87,7 @@ ZFile* Globals::GetSegment(int32_t segment, int workerID)
 			int idx = std::find(workerData[workerID]->segments.begin(),
 			                    workerData[workerID]->segments.end(), segment) -
 			          workerData[workerID]->segments.begin();
-			return workerData[workerID]->files[idx];
+			return workerData[workerID]->segmentFiles[idx];
 		}
 		else
 			return nullptr;
@@ -91,7 +97,7 @@ ZFile* Globals::GetSegment(int32_t segment, int workerID)
 		if (HasSegment(segment, workerID))
 		{
 			int idx = std::find(segments.begin(), segments.end(), segment) - segments.begin();
-			return files[idx];
+			return segmentFiles[idx];
 		}
 		else
 			return nullptr;

--- a/ZAPD/Globals.h
+++ b/ZAPD/Globals.h
@@ -48,6 +48,7 @@ public:
 	std::vector<ZFile*> files;
 	std::vector<ZFile*> externalFiles;
 	std::vector<int32_t> segments;
+	std::vector<ZFile*> segmentFiles;
 
 	std::map<int, FileWorker*> workerData;
 

--- a/ZAPD/Main.cpp
+++ b/ZAPD/Main.cpp
@@ -271,6 +271,7 @@ int ExtractFunc(int workerID, int fileListSize, std::string fileListItem, ZFileM
 
 		Globals::Instance->externalFiles.clear();
 		Globals::Instance->segments.clear();
+		Globals::Instance->segmentFiles.clear();
 		Globals::Instance->cfg.segmentRefFiles.clear();
 	}
 	else
@@ -286,6 +287,7 @@ int ExtractFunc(int workerID, int fileListSize, std::string fileListItem, ZFileM
 
 		Globals::Instance->workerData[workerID]->externalFiles.clear();
 		Globals::Instance->workerData[workerID]->segments.clear();
+		Globals::Instance->workerData[workerID]->segmentFiles.clear();
 		Globals::Instance->workerData[workerID]->segmentRefFiles.clear();
 
 		numWorkersLeft--;


### PR DESCRIPTION
We can not use the overall list of files because that can have duplicates in the case of certain include patterns and isn't necessarily 1-1 with the segments.

Fixes SoS ocarina effect texture extraction.