### PR TITLE
Fix sample exporting

### DIFF
--- a/ZAPD/ZAudio.cpp
+++ b/ZAPD/ZAudio.cpp
@@ -125,7 +125,7 @@ SampleEntry* ZAudio::ParseSampleEntry(const std::vector<uint8_t>& audioBank,
 	int loopOffset = BitConverter::ToInt32BE(audioBank, sampleOffset + 8) + baseOffset;
 	int bookOffset = BitConverter::ToInt32BE(audioBank, sampleOffset + 12) + baseOffset;
 
-	if (samples.find((uint64_t)sampleDataOffset) == samples.end())
+	if (samples.find(sampleDataOffset) == samples.end())
 	{
 		SampleEntry* sample = new SampleEntry();
 

--- a/ZAPD/ZAudio.h
+++ b/ZAPD/ZAudio.h
@@ -92,37 +92,37 @@ public:
 	std::vector<AudioTableEntry> sequenceTable;
 	std::vector<AudioTableEntry> sampleBankTable;
 	std::vector<std::vector<char>> sequences;
-	std::map<uint32_t, SampleEntry*> samples;
+	std::map<uint64_t, SampleEntry*> samples;
 	std::vector<std::vector<uint32_t>> fontIndices;
 	std::vector<std::string> seqNames;
 	std::map<uint32_t, std::string> soundFontNames;
 
-	// First Key = Bank ID, Sec Key = LoopDataOffset, Third Key = Sample Data Offset
-	std::map<uint32_t, std::map<uint32_t, std::map<uint32_t, std::string>>> sampleOffsets;
+	// First Key = Bank ID, Sec Key = Sample Data Offset, Third Key = LoopDataOffset,
+	std::map<uint32_t, std::map<uint32_t, std::string>> sampleOffsets;
 
 	// Key = Loop Offset, Value = Sample Offset
-	std::map<uint32_t, uint32_t> specialLoopSamples;
+	std::map<uint64_t, uint32_t> loopOverrideSamples;
 
 	ZAudio(ZFile* nParent);
 
 	void ParseXML(tinyxml2::XMLElement* reader) override;
 
-	std::vector<AdsrEnvelope*> ParseEnvelopeData(std::vector<uint8_t> audioBank, std::vector<uint8_t> audioTable,
+	std::vector<AdsrEnvelope*> ParseEnvelopeData(const std::vector<uint8_t>& audioBank, const std::vector<uint8_t>& audioTable,
 	                               int envelopeOffset, int baseOffset);
 
-	SoundFontEntry* ParseSoundFontEntry(std::vector<uint8_t> audioBank,
-	                                    std::vector<uint8_t> audioTable,
+	SoundFontEntry* ParseSoundFontEntry(const std::vector<uint8_t>& audioBank,
+	                                    const std::vector<uint8_t>& audioTable,
 	                                    AudioTableEntry audioSampleBankEntry, int bankIndex,
 	                                    int soundFontOffset,
 	                                    int baseOffset);
 
-	SampleEntry* ParseSampleEntry(std::vector<uint8_t> audioBank, std::vector<uint8_t> audioTable,
+	SampleEntry* ParseSampleEntry(const std::vector<uint8_t>& audioBank, const std::vector<uint8_t>& audioTable,
 	                              AudioTableEntry audioSampleBankEntry, int bankIndex,
 	                              int sampleOffset, int baseOffset);
 
-	std::vector<AudioTableEntry> ParseAudioTable(std::vector<uint8_t> codeData, int baseOffset);
-	void ParseSoundFont(std::vector<uint8_t> codeData, std::vector<uint8_t> audioTable,
-	                    std::vector<AudioTableEntry> audioSampleBank, AudioTableEntry& entry);
+	std::vector<AudioTableEntry> ParseAudioTable(const std::vector<uint8_t>& codeData, int baseOffset);
+	void ParseSoundFont(const std::vector<uint8_t>& codeData, const std::vector<uint8_t>& audioTable,
+	                    const std::vector<AudioTableEntry>& audioSampleBank, AudioTableEntry& entry);
 
 	void ParseRawData() override;
 

--- a/ZAPD/ZAudio.h
+++ b/ZAPD/ZAudio.h
@@ -92,16 +92,13 @@ public:
 	std::vector<AudioTableEntry> sequenceTable;
 	std::vector<AudioTableEntry> sampleBankTable;
 	std::vector<std::vector<char>> sequences;
-	std::map<uint64_t, SampleEntry*> samples;
+	std::map<uint32_t, SampleEntry*> samples;
 	std::vector<std::vector<uint32_t>> fontIndices;
 	std::vector<std::string> seqNames;
 	std::map<uint32_t, std::string> soundFontNames;
 
 	// First Key = Bank ID, Sec Key = Sample Data Offset, Third Key = LoopDataOffset,
 	std::map<uint32_t, std::map<uint32_t, std::string>> sampleOffsets;
-
-	// Key = Loop Offset, Value = Sample Offset
-	std::map<uint64_t, uint32_t> loopOverrideSamples;
 
 	ZAudio(ZFile* nParent);
 

--- a/ZAPD/ZAudio.h
+++ b/ZAPD/ZAudio.h
@@ -97,7 +97,7 @@ public:
 	std::vector<std::string> seqNames;
 	std::map<uint32_t, std::string> soundFontNames;
 
-	// First Key = Bank ID, Sec Key = Sample Data Offset, Third Key = LoopDataOffset,
+	// First Key = Bank ID, Sec Key = Sample Data Offset.
 	std::map<uint32_t, std::map<uint32_t, std::string>> sampleOffsets;
 
 	ZAudio(ZFile* nParent);


### PR DESCRIPTION
A lot of samples were duplicated with attributes for `LoopOffset`. This attribute was not used in OOT or MM decomp so it was removed. This is matched by a PR in OTRExporter and they should be merged together.